### PR TITLE
Revert "[WA] Fix the sync issue between HVAC app and KitchSink app"

### DIFF
--- a/automotive/vehicle/2.0/default/impl/vhal_v2_0/EmulatedVehicleHal.cpp
+++ b/automotive/vehicle/2.0/default/impl/vhal_v2_0/EmulatedVehicleHal.cpp
@@ -155,15 +155,6 @@ StatusCode EmulatedVehicleHal::set(const VehiclePropValue& propValue) {
 
     if (!mPropStore->writeValue(propValue)) {
         return StatusCode::INVALID_ARG;
-    } else {
-       /*
-        * w/a for the sync issue of HVAC app and KitchSink app.
-        * Currently, there's no real vehicle system for our platform, when we set a property
-        * to vehicle, there's no feedback. So when set a value on HVAC app or KitchSink app,
-        * there will no notification to the other app.
-        * We report a HAL event here to w/a this issue.
-        */
-        doHalEvent(getValuePool()->obtain(propValue));
     }
 
     getEmulatorOrDie()->doSetValueFromClient(propValue);


### PR DESCRIPTION
This reverts commit 369096872c3d80bce4bacd907770796d9cacf2c1.
Revert the github patch and use the google-diff patch instead.

Jira: OAM-65770
Test: Refer to the steps from JIRA
Signed-off-by: Lei,RayX <rayx.lei@intel.com>