### PR TITLE
Revert "Add to support the VehicleProperty HVAC_SEAT_TEMPERATURE"

### DIFF
--- a/automotive/vehicle/2.0/default/impl/vhal_v2_0/DefaultConfig.h
+++ b/automotive/vehicle/2.0/default/impl/vhal_v2_0/DefaultConfig.h
@@ -211,23 +211,6 @@ const ConfigDeclaration kVehicleProperties[]{
      .initialAreaValues = {{toInt(VehicleAreaZone::ROW_1_LEFT), {.floatValues = {16}}},
                            {toInt(VehicleAreaZone::ROW_1_RIGHT), {.floatValues = {20}}}}},
 
-    {.config = {.prop = toInt(VehicleProperty::HVAC_SEAT_TEMPERATURE),
-                .access = VehiclePropertyAccess::READ_WRITE,
-                .changeMode = VehiclePropertyChangeMode::ON_CHANGE,
-                .supportedAreas = VehicleAreaZone::ROW_1_LEFT | VehicleAreaZone::ROW_1_RIGHT,
-                .areaConfigs = {VehicleAreaConfig{
-                                    .areaId = toInt(VehicleAreaZone::ROW_1_LEFT),
-                                    .minInt32Value = 0,
-                                    .maxInt32Value = 3,
-                                },
-                                VehicleAreaConfig{
-                                    .areaId = toInt(VehicleAreaZone::ROW_1_RIGHT),
-                                    .minInt32Value = 0,
-                                    .maxInt32Value = 3,
-                                }}},
-     .initialAreaValues = {{toInt(VehicleAreaZone::ROW_1_LEFT), {.int32Values = {0}}},
-                           {toInt(VehicleAreaZone::ROW_1_RIGHT), {.int32Values = {0}}}}},
-
     {.config =
          {
              .prop = toInt(VehicleProperty::ENV_OUTSIDE_TEMPERATURE),


### PR DESCRIPTION
This reverts commit 520ab3d6c44f98e6b6fc444e84568629852c5d63.
Revert the github patch and use the google-diff patch instead.

Jira: OAM-65772
Test: Refer to the steps from JIRA
Signed-off-by: Lei,RayX <rayx.lei@intel.com>